### PR TITLE
Show errors during install script download

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -2,13 +2,14 @@
 
 SETUP_DIR=$HOME/.pio
 INSTALLED_FLAG=$SETUP_DIR/installed
+INSTALL_SCRIPT_PATH='https://raw.githubusercontent.com/apache/incubator-predictionio/master/bin/install.sh'
 
 mkdir -p $SETUP_DIR
 
 if [ ! -f $INSTALLED_FLAG ]; then
 
   echo "Installing PredictionIO..."
-  bash -e -c "$(curl -s https://install.prediction.io/install.sh)" 0 -y
+  bash -e -c "$(curl -s $INSTALL_SCRIPT_PATH)" 0 -y
   if [ $? -ne 0 ]; then
 
     echo "ERROR: PredictionIO installation failed."

--- a/provision.sh
+++ b/provision.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
 SETUP_DIR=$HOME/.pio
-INSTALLED_FLAG=$SETUP_DIR/installed
 
 mkdir -p $SETUP_DIR
 
-if [ ! -f $INSTALLED_FLAG ]; then
+if [ ! -x "$(command -v pio-start-all)" ]; then
 
   echo "Installing PredictionIO..."
   bash -e -c "$(curl -s https://install.prediction.io/install.sh)" 0 -y
@@ -23,7 +22,6 @@ if [ ! -f $INSTALLED_FLAG ]; then
   else
 
     echo "Finish PredictionIO installation."
-    touch $INSTALLED_FLAG
 
   fi
 

--- a/provision.sh
+++ b/provision.sh
@@ -8,7 +8,7 @@ mkdir -p $SETUP_DIR
 if [ ! -f $INSTALLED_FLAG ]; then
 
   echo "Installing PredictionIO..."
-  bash -e -c "$(curl -s https://install.prediction.io/install.sh)" 0 -y
+  bash -e -c "$(curl -sS https://install.prediction.io/install.sh)" 0 -y
   if [ $? -ne 0 ]; then
 
     echo "ERROR: PredictionIO installation failed."


### PR DESCRIPTION
to see the dns resolution error:
```
curl: (6) Could not resolve host: install.prediction.io
```